### PR TITLE
Update translators and translation coordinators

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,58 +5,66 @@ Translations are managed via [Transifex](https://www.transifex.com/projects/p/sc
 
 ## Translation Map
 
-| Language              |  Intl Code    | Translator              | Transifex | SVN |      
-|:----------------------|:--------------|:-----------------------:|:---------:|:---:|
-| English (UK)          |en_UK          | Craig Bradney           |           |:+1: |
-| English (AUS)         |en_AU          | Craig Bradney           |           |:+1: |
-| Afrikaans             |af             |                         |           |     |
-| Esperanto             |eo             | Pier Luigi Cinquantini  |   :+1:    |     |
-| French                |fr             | Jean Ghali              |           |:+1: |
-| German                |de             | Christoph S             |           |:+1: |
-| German (Trad.)        |de_1901        | Christoph S             |           |:+1: |
-| German (Swiss)        |de_CH          | Christoph S             |           |:+1: |
-| Bulgarian             |bg             |                         |           |     |
-| Swedish               |sv             |                         |           |     |
-| Solvenia              |sl             | MartinSrebotnjak @filmsi|   :+1:    |     |
-| Slovak (Slovakia)     |sk_SK          | @zdpo                   |   :+1:    |     |
-| Ukranian              |uk             |                         |           |     |
-| Serbian               |sr             |                         |           |     |
-| Russian               |ru             | @prokoudine             |   :+1:    |     |
-| Albanian              |sq             |                         |           |     |
-| Polish                |pl_PL          | Maciej Hański           |           |     |
-| Galacian              |gl             | Xose Calvo              |   :+1:    |     |
-| Hungarian             |hu             | @gyuris / bubu          |   :+1:    |     |
-| Danish (Denmark)      |da_DK          | Morten Langlo           |           |:+1: |
-| Norwegian Bokmål      |nb_NO          |                         |           |     |
-| Finnish               |fi             | Tsoots                  |   :+1:    |     |
-| Italian               |it             | @FirasH                 |           |:+1: |
-| Piemontese            |pms            | Randy Ichinose          |   :+1:    |     |
-| Catalan               |ca             |                         |           |     |
-| Greek                 |el             |                         |           |     |
-| Turkish               |tr             |                         |           |     |
-| Portuguese (Brazil)   |pt_BR          |                         |           |     |
-| Portuguese (Portugal) |pt_PT          |                         |           |     |
-| Spanish (Spain)       |es_ES          |                         |           |     |
-| Basque                |eu             | Asier Sarasua Garmendia |   :+1:    |     |
-| Lithuanian            |lt_LT          |                         |           |     |
-| Estonian              |et             |                         |           |     |
-| Breton                |br             | alan.monfort            |   :+1:    |     |
-| Czech (Czech Republic)|cs_CZ          |                         |           |     |
-| Dutch                 |nl             | Foppe Benedictus        |   :+1:    |     |
-| Welsh                 |cy             |                         |           |     |
-| Kabyle                |kab            |                         |   :+1:    |     |
-| Somali                |so             |                         |   :+1:    |     |
-| Indonesian            |id             | Ade Malsasa Akbar       |   :+1:    |     |
-| Sanskrit              |sa             |                         |           |     |
-| Telugu                |te             |                         |           |     |
-| Hindi (India)         |hi_IN          |                         |           |     |
-| Kannada (India)       |kn_IN          | Sarath M S (@sarathms)  |   :+1:    |     |
-| Chinese (China)       |zh_CN          |                         |           |     |
-| Chinese (Taiwan)      |zh_TW          |                         |           |     |
-| Japanese              |jp             | Fuminobu Takeyama @ftake|   :+1:    |     |
-| Korean                |ko             |                         |           |     |
-| Arabic                |ar             | Hatim alahmadi & @moceap|   :+1:    |     |
-| Hebrew                |he_IL          | @luzpaz                 |   :+1:    |     |
+Language              | Code    | Method    | Translator / Translation coordinator
+:---------------------|:--------|:----------|:------------------------------------
+Afrikaans             | af      |           | :x:
+Albanian              | sq      |           | :x:
+Arabic                | ar      | Transifex | [Fahad Al-Saidi](https://www.transifex.com/user/profile/fahad.alsaidi/) @Fahad-Alsaidi, [Khaled Hosny](https://www.transifex.com/user/profile/khaled/) @khaledhosny, [Mosaab Alzoubi](https://www.transifex.com/user/profile/moceap/) @moceap
+Basque                | eu      | Transifex | [Asier Sarasua Garmendia](https://www.transifex.com/user/profile/assar/)
+Breton                | br      | Transifex | [Alan Monfort](https://www.transifex.com/user/profile/Alan_Drouizig/)
+Bulgarian             | bg      | Transifex | [Mihail Andreev](https://www.transifex.com/user/profile/miAndreev/)
+Catalan               | ca      | Transifex | [Ecron](https://www.transifex.com/user/profile/Ecron/), [Aleix Vidal i Gaya](https://www.transifex.com/user/profile/leixet/)
+Chinese (China)       | zh_CN   | Transifex | [Mingye Wang](https://www.transifex.com/user/profile/Arthur200000/)
+Chinese (Taiwan)      | zh_TW   | Transifex | [taijuin](https://www.transifex.com/user/profile/taijuin/), [Supaplex](https://www.transifex.com/user/profile/Supaplex/)
+Croatian (Croatia)    | hr_HR   | Transifex | [Dubravko Cvikl](https://www.transifex.com/user/profile/dcvikl/)
+Czech (Czech Republic)| cs_CZ   | Transifex | [Svatopluk Vít](https://www.transifex.com/user/profile/svatas/)
+Danish (Denmark)      | da_DK   | SVN       | [Morten Langlo](https://www.transifex.com/user/profile/mlanglo/)
+Dutch                 | nl      | Transifex | [Foppe Benedictus](https://www.transifex.com/user/profile/Fopper/)
+English (AUS)         | en_AU   | SVN       | [Craig Bradney](https://www.transifex.com/user/profile/cbradney/) (MrB) @MrB74
+English (India)       | en_IN   | Transifex | [Priyansh Singh](https://www.transifex.com/user/profile/abstractclass/)
+English (UK)          | en_GB   | SVN       | [Craig Bradney](https://www.transifex.com/user/profile/cbradney/) (MrB) @MrB74
+Esperanto             | eo      | Transifex | [Pier Luigi Cinquantini](https://www.transifex.com/user/profile/Petro_Ludoviko/)
+Estonian              | et      |           | :x:
+Finnish               | fi      | Transifex | [Riku Leino](https://www.transifex.com/user/profile/Tsoots/)
+French                | fr      | SVN       | Jean Ghali (jghali)
+Galacian              | gl      | Transifex | [Xosé Calvo](https://www.transifex.com/user/profile/xosecalvo/)
+German                | de      | SVN       | Christoph Schäfer (christoph_s)
+German (Trad.)        | de_1901 | SVN       | Christoph Schäfer (christoph_s)
+German (Swiss)        | de_CH   | SVN       | Christoph Schäfer (christoph_s)
+Greek                 | el      | Transifex | [Marinus Savoritias](https://www.transifex.com/user/profile/Savvoritias/)
+Hebrew                | he_IL   | Transifex | [Iaacov Rosenberg](https://www.transifex.com/user/profile/iaacov/), ~~@luzpaz~~
+Hindi (India)         | hi_IN   | Transifex | [Priyansh Singh](https://www.transifex.com/user/profile/abstractclass/)
+Hungarian             | hu      | Transifex | [Gyuris Gellért](https://www.transifex.com/user/profile/bubu/) @gyuris
+Indonesian            | id      | Transifex | [Ade Malsasa Akbar](https://www.transifex.com/user/profile/Malsasa/)
+Italian               | it      | SVN       | [Alessandro Levati](https://www.transifex.com/user/profile/alex326/), [Firas Hanife](https://www.transifex.com/user/profile/FirasH/) @FirasH
+Japanese              | ja      | Transifex | [武山文信 Fuminobu Takeyama](https://www.transifex.com/user/profile/ftakeyama/) @ftake
+Kabyle                | kab     | Transifex | [Yacine Bouklif](https://www.transifex.com/user/profile/Yacine2953/)
+Kannada (India)       | kn_IN   | Transifex | [Sarath M S](https://www.transifex.com/user/profile/sarathms/) @sarathms
+Korean                | ko      | Transifex | [오민우 ](https://www.transifex.com/user/profile/ODS12/)
+Lithuanian            | lt_LT   | Transifex | [Antanas Budriūnas](https://www.transifex.com/user/profile/antanasb/)
+Mongolian (Mongolia)  | mn_MN   | Transifex | [Popolon](https://www.transifex.com/user/profile/Popolon/)
+Norwegian Bokmål      | nb_NO   | Transifex | [Axel Bojer](https://www.transifex.com/user/profile/axelb/)
+Occitan (post 1500)   | oc      | Transifex | [Cédric Valmary](https://www.transifex.com/user/profile/Cedric31/)
+Persian (Iran)        | fa_IR   | Transifex | [Mohammad Zokaie](https://www.transifex.com/user/profile/emzi/)
+Piemontese            | pms     | Transifex | [Randy Ichinose](https://www.transifex.com/user/profile/them0neygoround/)
+Polish                | pl_PL   | Transifex | [Piotr Strębski](https://www.transifex.com/user/profile/strebski/), ~~Maciej Hański~~
+Portuguese (Brazil)   | pt_BR   | Transifex | [Farid Abdelnour](https://www.transifex.com/user/profile/osc/)
+Portuguese (Portugal) | pt_PT   | Transifex | [Paulo Pereira](https://www.transifex.com/user/profile/horus68/), [Rui](https://www.transifex.com/user/profile/xendez/)
+Russian               | ru      | Transifex | [Alexandre Prokoudine](https://www.transifex.com/user/profile/prokoudine/) @prokoudine
+Sanskrit              | sa      |           | :x:
+Serbian               | sr      | Transifex | [Мирослав Николић](https://www.transifex.com/user/profile/MirosNik/)
+Sinhala               | si      | Transifex | [Pathum Egodawatta](https://www.transifex.com/user/profile/pathumego/)
+Slovak (Slovakia)     | sk_SK   | Transifex | [Zdenko Podobný](https://www.transifex.com/user/profile/zdpo/) @zdpo
+Slovenian             | sl      | Transifex | [Martin Srebotnjak](https://www.transifex.com/user/profile/filmsi/)
+Somali                | so      | Transifex | [Mohamed Abdi](https://www.transifex.com/user/profile/gudaal10/)
+Spanish (Argentina)   | es_AR   | Transifex | [Diego Morejón](https://www.transifex.com/user/profile/diegox2493/)
+Spanish (Spain)       | es_ES   | Transifex | [Adrián Prado](https://www.transifex.com/user/profile/apradoc/)
+Swedish               | sv      | Transifex | [Henrik Mattsson-Mårn](https://www.transifex.com/user/profile/rchk/)
+Tamil                 | ta      | Transifex | [Bagavathikumar Ramakrishnan](https://www.transifex.com/user/profile/Bagavathikumar/)
+Telugu                | te      | Transifex | [ప్రవీణ్ ఇళ్ళ](https://www.transifex.com/user/profile/Praveen_Illa/)
+Turkish               | tr      | Transifex | [Necdet Yücel](https://www.transifex.com/user/profile/necdetyucel/)
+Ukranian              | uk      |           | :x:
+Welsh                 | cy      | Transifex | [Aled Powell](https://www.transifex.com/user/profile/Cymrodor/)
 
 ## Tracking correct Translations
 Organizing Transifex vs. SVN  


### PR DESCRIPTION
Update translators and translation coordinators from Transifex. 

Please check @luzpaz in [Hebrew team](https://www.transifex.com/scribus/teams/41672/he_IL/) and Maciej Hański in [Polish team](https://www.transifex.com/scribus/teams/41672/pl_PL/). According to the previous version they are the translation coordinators, but I did not find them.